### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/Score.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/Score.java
@@ -43,11 +43,11 @@ public final class Score {
       sb.append(each + " ");
       i++;
       if ((i % 4) == 0) {
-        out.println("> " + sb.toString());
+        out.println("> " + sb );
         sb = new StringBuilder();
       }
     }
-    out.println("> " + sb.toString());
+    out.println("> " + sb );
   }
 
   public String getMutatorName() {

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/Score.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/Score.java
@@ -43,11 +43,11 @@ public final class Score {
       sb.append(each + " ");
       i++;
       if ((i % 4) == 0) {
-        out.println("> " + sb );
+        out.println("> " + sb);
         sb = new StringBuilder();
       }
     }
-    out.println("> " + sb );
+    out.println("> " + sb);
   }
 
   public String getMutatorName() {

--- a/pitest/src/main/java/org/pitest/util/Log.java
+++ b/pitest/src/main/java/org/pitest/util/Log.java
@@ -79,7 +79,7 @@ public class Log {
       if (throwable != null) {
         final StringWriter sink = new StringWriter();
         throwable.printStackTrace(new PrintWriter(sink, true));
-        buf.append(sink.toString());
+        buf.append(sink);
       }
 
       return buf.toString();


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:2017798326 -->
<!-- fingerprint:-818046021 -->
<!-- fingerprint:753652600 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (3)
